### PR TITLE
Added walls of ipa-office simulation environment to spawned objects

### DIFF
--- a/cob_default_env_config/ipa-office/object_locations.yaml
+++ b/cob_default_env_config/ipa-office/object_locations.yaml
@@ -1,0 +1,12 @@
+
+walls:
+  model: ipa-office_walls
+  model_type: urdf
+  position: [ 0, 0, 0]
+  orientation: [ 0, 0, 0]
+
+# reflector_marker_01:
+#   model: reflector_marker
+#   model_type: urdf
+#   position: [ 0, 0, 0]
+#   orientation: [ 0, 0, 0]


### PR DESCRIPTION
In this PR the walls for the new ipa-office simulation environment were added to the spawn object locations yaml.

This PR is related to https://github.com/ipa320/cob_simulation/pull/115
